### PR TITLE
register .vala and .vapi files as autolaods

### DIFF
--- a/vala-mode.el
+++ b/vala-mode.el
@@ -340,8 +340,9 @@
 ;;		  ;; irrelevant menu alternatives.
 ;;		  (cons "Vala" (c-lang-const c-mode-menu vala)))
 
-;;; Autoload mode trigger
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.vala$" . vala-mode))
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.vapi$" . vala-mode))
 
 ;; Custom variables


### PR DESCRIPTION
We want a major mode to be activated when we open files with specific
extensions.  Make the vala mode acts like others; associate .vala and
.vapi extensions as autoload.

This fixes #1