### PR TITLE
vala-mode: add missing require

### DIFF
--- a/vala-mode.el
+++ b/vala-mode.el
@@ -48,6 +48,7 @@
 
 ;; This is a copy of the function in cc-mode which is used to handle
 ;; the eval-when-compile which is needed during other times.
+(require 'cc-defs)
 (defun c-filter-ops (ops opgroup-filter op-filter &optional xlate)
   ;; See cc-langs.el, a direct copy.
   (unless (listp (car-safe ops))


### PR DESCRIPTION
c-lang-const is a macro, so need to ensure cc-defs is loaded before
vala-mode.

I guess this was not fixed before because who loads vala-mode before loading
c-mode?!