### PR TITLE
fontyificaton workaround for Emacs 27

### DIFF
--- a/vala-mode.el
+++ b/vala-mode.el
@@ -134,7 +134,7 @@
 	   ;; Match a char before the string starter to make
 	   ;; `c-skip-comments-and-strings' work correctly.
 	   (concat ".\\(" c-string-limit-regexp "\\)")
-	   '((c-font-lock-invalid-string)))
+	   `(,(if (fboundp 'c-font-lock-invalid-string) '(c-font-lock-invalid-string))))
 	   
 	 ;; Fontify keyword constants.
 	 ,@(when (c-lang-const c-constant-kwds)


### PR DESCRIPTION
Since in Emacs 27 the function `c-font-lock-invalid-string` have been
deleted and the fontification rules in `vala-mode` use this function
thus resulting in messages in `*Messages*` buffer of the form

```
Error during redisplay: (jit-lock-function 534) signaled (void-function c-font-lock-invalid-string)
```

and the fontification stops before fontifing all of the buffer.

This commit has old behaviour only if `c-font-lock-invalid-string` is bound
during definition of `c-basic-matchers-before` otherwise it evals to `(nil)`.
After applying this commit fontification works in the whole buffer in Emacs 27.