### PR TITLE
fontify identifiers after types marked nullable

### DIFF
--- a/vala-mode.el
+++ b/vala-mode.el
@@ -190,6 +190,10 @@
 			       "\\)")
 		       "\\)*")))
 
+;; Vala type may be marked nullable and/or be array type
+(c-lang-defconst c-opt-type-suffix-key
+  vala "\\(\\[[ \t\n\r\f\v]*\\]\\|\\?\\)")
+
 ;; Vala has a few rules that are slightly different than Java for
 ;; operators. This also removed the Java's "super" and replaces it
 ;; with the Vala's "base".


### PR DESCRIPTION
Now `func`, `arg` and `variable` are not properly fontified after nullable types in the following example
  
```
string? func (string? arg) { string? variable = arg; return variable; }
```

the commit does fontification of identifiers after nullable types, such as `string?` or `string?[]?`, as it now works for `string` and `string[]`.
