### PR TITLE
Fix pointers and constructor names

### DIFF
--- a/vala-mode.el
+++ b/vala-mode.el
@@ -221,10 +221,14 @@
 (c-lang-defconst c-type-prefix-kwds
   vala '("class" "interface" "struct" "enum" "signal"))
 
+;; Type modifier keywords which can appear in front of a type.
+(c-lang-defconst c-type-modifier-prefix-kwds
+  vala '("const"))
+
 ;; Type modifier keywords. They appear anywhere in types, but modifiy
 ;; instead create one.
 (c-lang-defconst c-type-modifier-kwds
-  vala '("const"))
+  vala nil)
 
 ;; Structures that are similiar to classes.
 (c-lang-defconst c-class-decl-kwds

--- a/vala-mode.el
+++ b/vala-mode.el
@@ -192,7 +192,7 @@
 
 ;; Vala type may be marked nullable and/or be array type
 (c-lang-defconst c-opt-type-suffix-key
-  vala "\\(\\[[ \t\n\r\f\v]*\\]\\|\\?\\)")
+  vala "\\(\\[[ \t\n\r\f\v]*\\]\\|[?*]\\)")
 
 ;; Vala has a few rules that are slightly different than Java for
 ;; operators. This also removed the Java's "super" and replaces it


### PR DESCRIPTION
1. The first commit adds fontification of identifiers after pointer
types (similar to nullable types before), for example

```
public int*[]? func(int*[]? param) { int*[]? variable = param; return variable; }
```

2. The second commit brings fontifing of constructor names: this is a
side effect of allowing `const` only before the type not inside the
type (for example `abc` below was fontified before although there is
syntax error, with this commit `abc` is no longer fontified, as
`const` is now not allowed inside the type):

```
public class Class1 {
    public Class1 () {}
    const string ABC = "abc";
    string const abc = "abc"; // syntax error
}
```

`ABC` is still fontified correctly, although it is independent of adding
`const` to `c-type-modifier-prefix-kwds` (if it would be set to `nil`
instead of `'("const")` then `ABC` would still be fontified).
