### PR TITLE
Don't ignore file local and directory local variables

### DIFF
--- a/vala-mode.el
+++ b/vala-mode.el
@@ -471,8 +471,8 @@ Key bindings:
   (setq tab-width 4)
   (c-toggle-auto-newline -1)
   (c-toggle-hungry-state -1)
-  (run-hooks 'c-mode-common-hook)
-  (run-hooks 'vala-mode-hook)
+  (run-mode-hooks 'c-mode-common-hook
+		  'vala-mode-hook)
   (c-update-modeline))
 
 (provide 'vala-mode)


### PR DESCRIPTION
Currently, it is not possible to set any file local and directory
local variables, for Vala files, because vala-mode ignores them.

This commit fixes this problem by calling mode hooks via
run-mode-hooks, which ensures that local variables are properly set
up.